### PR TITLE
Allow clock skew between server and client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Erlang JWT Library
-=
+==================
+
 erljwt is a easy to use json web token [JWT] parsing and minting library.
 JWT is a simple authorization token [RFC7519](https://www.rfc-editor.org/rfc/rfc7519.txt) based on JSON.
 
@@ -58,3 +59,13 @@ You get back the original claims, plus expiration claim and the header and signa
     }
 }
 ```
+
+## Configuration
+
+In checking expiration and not-before timestamps there is an allowed clock difference.
+This fixes the problem that servers might not have synchronized clocks.
+
+Per default the allowed difference is 300 seconds (5 minutes).
+
+This can be changed via the application env key `clock_skew`. The current allowed
+clock skew can be requested with `erljwt:clock_skew()`.

--- a/include/erljwt.hrl
+++ b/include/erljwt.hrl
@@ -23,7 +23,3 @@
 -type jwt_result() :: {ok, #{ header => _, claims => _, signatrue => _}}
                 | error_res().
 -type key_result() :: {ok, key()} | error_res().
-
-% Allowed clock difference in seconds between server and client when checking
-% the nbf (not yet valid) check.
--define(JWT_ALLOWED_CLOCK_SKEW, 300).

--- a/include/erljwt.hrl
+++ b/include/erljwt.hrl
@@ -23,3 +23,7 @@
 -type jwt_result() :: {ok, #{ header => _, claims => _, signatrue => _}}
                 | error_res().
 -type key_result() :: {ok, key()} | error_res().
+
+% Allowed clock difference in seconds between server and client when checking
+% the nbf (not yet valid) check.
+-define(JWT_ALLOWED_CLOCK_SKEW, 300).

--- a/src/erljwt.erl
+++ b/src/erljwt.erl
@@ -172,7 +172,8 @@ already_valid(undefined) ->
     true;
 already_valid(NotBefore) when is_number(NotBefore) ->
     SecondsPassed = erljwt_util:epoch() - NotBefore,
-    SecondsPassed >= 0;
+    % security standards suggest to accept up to 5 minutes clock skew
+    SecondsPassed >= -?JWT_ALLOWED_CLOCK_SKEW;
 already_valid(_) ->
     false.
 

--- a/src/erljwt.erl
+++ b/src/erljwt.erl
@@ -13,9 +13,15 @@
 -export([to_map/1]).
 -export([create/3, create/4, create/5]).
 -export([algorithms/0]).
+-export([clock_skew/0]).
 
 -define(ALL_ALGOS, [none, hs256, hs384, hs512, rs256, rs384, rs512,
                     es256, es384, es512]).
+
+
+% Default allowed clock difference in seconds between server and client
+% when checking the nbf (not yet valid) check.
+-define(JWT_ALLOWED_CLOCK_SKEW, 300).
 
 -spec algorithms() -> algo_list().
 algorithms() ->
@@ -58,6 +64,11 @@ create(Alg, ClaimSetMap, HeaderMapIn, ExpirationSeconds, Key)
     Header = base64url:encode(jsone:encode(HeaderMap)),
     Payload = <<Header/binary, ".", ClaimSet/binary>>,
     return_signed_jwt(Alg, Payload, Key).
+
+%% @doc Allowed clock skew when checking not-valid-before and -after timestamps.
+-spec clock_skew() -> non_neg_integer().
+clock_skew() ->
+    application:get_env(erljwt, clock_skew, ?JWT_ALLOWED_CLOCK_SKEW).
 
 
 %% ========================================================================
@@ -173,7 +184,7 @@ already_valid(undefined) ->
 already_valid(NotBefore) when is_number(NotBefore) ->
     SecondsPassed = erljwt_util:epoch() - NotBefore,
     % security standards suggest to accept up to 5 minutes clock skew
-    SecondsPassed >= -?JWT_ALLOWED_CLOCK_SKEW;
+    SecondsPassed >= 0 - clock_skew();
 already_valid(_) ->
     false.
 

--- a/test/erljwt_test.erl
+++ b/test/erljwt_test.erl
@@ -181,7 +181,7 @@ exp_fail_test() ->
 iat_fail_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{iat => (Now + 10 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
+    Claims = maps:merge(#{iat => (Now + 10 + erljwt:clock_skew())}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     {error, not_issued_in_past} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS).
 
@@ -196,14 +196,14 @@ iat_test() ->
 nbf_fail_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{nbf => (Now + 1 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
+    Claims = maps:merge(#{nbf => (Now + 1 + erljwt:clock_skew())}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     {error, not_yet_valid} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS).
 
 nbf_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{nbf => (Now + 1 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
+    Claims = maps:merge(#{nbf => (Now + 1 + erljwt:clock_skew())}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     timer:sleep(2000),
     {ok, Result} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS),

--- a/test/erljwt_test.erl
+++ b/test/erljwt_test.erl
@@ -2,6 +2,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
+-include("../include/erljwt.hrl").
+
 -define(OCT_JWK, #{ kty => <<"oct">>, k => <<"my secret key">>} ).
 
 -define(RSA_JWK, #{ kty => <<"RSA">>,
@@ -179,7 +181,7 @@ exp_fail_test() ->
 iat_fail_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{iat => (Now + 10)}, claims()),
+    Claims = maps:merge(#{iat => (Now + 10 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     {error, not_issued_in_past} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS).
 
@@ -194,14 +196,14 @@ iat_test() ->
 nbf_fail_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{nbf => (Now + 1)}, claims()),
+    Claims = maps:merge(#{nbf => (Now + 1 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     {error, not_yet_valid} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS).
 
 nbf_test() ->
     application:set_env(erljwt, add_iat, true),
     Now = erlang:system_time(seconds),
-    Claims = maps:merge(#{nbf => (Now + 1)}, claims()),
+    Claims = maps:merge(#{nbf => (Now + 1 + ?JWT_ALLOWED_CLOCK_SKEW)}, claims()),
     JWT = erljwt:create(rs256, Claims, 10, ?RSA_JWK),
     timer:sleep(2000),
     {ok, Result} = erljwt:validate(JWT, erljwt:algorithms(), #{}, ?JWS),


### PR DESCRIPTION
This fixes an issue where a JWT is rejected if the clocks of the server is significantly different from the clock of the client.

Some sources suggest clocks skew defaults of up to 5 minutes.

See for example:

https://docs.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.defaultclockskew

With thanks to @robvandenbogaard
